### PR TITLE
Optimizing Event/Trait insertion in SqlAlchemy

### DIFF
--- a/ceilometer/tests/storage/test_storage_scenarios.py
+++ b/ceilometer/tests/storage/test_storage_scenarios.py
@@ -2119,11 +2119,13 @@ class GetEventTest(EventTestBase):
             now = now + datetime.timedelta(hours=1)
         self.end = now
 
-        self.conn.record_events(event_models)
+        prob = self.conn.record_events(event_models)
+        self.assertEqual(0, len(prob), prob)
 
     def test_simple_get(self):
         event_filter = storage.EventFilter(self.start, self.end)
         events = self.conn.get_events(event_filter)
+        #self.fail(self.conn.get_traits())
         self.assertEqual(3, len(events))
         start_time = None
         for i, name in enumerate(["Foo", "Bar", "Zoo"]):

--- a/etc/ceilometer/ceilometer.conf.sample
+++ b/etc/ceilometer/ceilometer.conf.sample
@@ -602,6 +602,14 @@
 #time_to_live=-1
 
 
+#
+# Options defined in ceilometer.storage.impl_sqlalchemy
+#
+
+# Max size of the unique name cache (integer value)
+#unique_name_cache_size=500
+
+
 [alarm]
 
 #


### PR DESCRIPTION
1) Adding a cache for UniqueNames so that the driver doesn't
have to go out to the database every time it is creating a trait
or event.

2) Bulk insertion of an Event's Traits.
